### PR TITLE
SWF-4517 : remove prefix project name 'eXo Add-on:: ' to exclude it from Sonar supported addons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>platform-sample-acme-website</artifactId>
   <version>4.4.x-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>eXo Add-on::  ACME Website sample for eXo platform</name>
+  <name>ACME Website sample for eXo platform</name>
 
   <scm>
     <connection>scm:git:git://github.com/exoplatform/acme-sample.git</connection>


### PR DESCRIPTION
Remove prefix project name 'eXo Add-on:: ' to exclude it from Sonar supported addons.